### PR TITLE
Visualize uninstrumented services in the dependency diagrams

### DIFF
--- a/examples/hotrod/services/customer/database.go
+++ b/examples/hotrod/services/customer/database.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -75,9 +74,8 @@ func newDatabase(tracer trace.Tracer, logger log.Factory) *database {
 func (d *database) Get(ctx context.Context, customerID int) (*Customer, error) {
 	d.logger.For(ctx).Info("Loading customer", zap.Int("customer_id", customerID))
 
-	ctx, span := d.tracer.Start(ctx, "SQL SELECT", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := d.tracer.Start(ctx, "SQL SELECT")
 	span.SetAttributes(
-		semconv.PeerServiceKey.String("mysql"),
 		attribute.
 			Key("sql.query").
 			String(fmt.Sprintf("SELECT * FROM customer WHERE customer_id=%d", customerID)),

--- a/examples/hotrod/services/driver/redis.go
+++ b/examples/hotrod/services/driver/redis.go
@@ -51,7 +51,8 @@ func newRedis(otelExporter string, metricsFactory metrics.Factory, logger log.Fa
 
 // FindDriverIDs finds IDs of drivers who are near the location.
 func (r *Redis) FindDriverIDs(ctx context.Context, location string) []string {
-	ctx, span := r.tracer.Start(ctx, "FindDriverIDs", trace.WithSpanKind(trace.SpanKindClient))
+	// Start a new span for FindDriverIDs
+	_, span := r.tracer.Start(ctx, "FindDriverIDs")
 	span.SetAttributes(attribute.Key("param.driver.location").String(location))
 	defer span.End()
 
@@ -69,7 +70,8 @@ func (r *Redis) FindDriverIDs(ctx context.Context, location string) []string {
 
 // GetDriver returns driver and the current car location
 func (r *Redis) GetDriver(ctx context.Context, driverID string) (Driver, error) {
-	ctx, span := r.tracer.Start(ctx, "GetDriver", trace.WithSpanKind(trace.SpanKindClient))
+	// Start a new span for GetDriver
+	_, span := r.tracer.Start(ctx, "GetDriver")
 	span.SetAttributes(attribute.Key("param.driverID").String(driverID))
 	defer span.End()
 

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -30,6 +31,9 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/tenancy"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 )
+
+// Global counter
+var counter uint64
 
 // Store is an in-memory store of traces
 type Store struct {
@@ -116,6 +120,43 @@ func (st *Store) GetDependencies(ctx context.Context, endTs time.Time, lookback 
 						deps[depKey] = &model.DependencyLink{
 							Parent:    parentSpan.Process.ServiceName,
 							Child:     s.Process.ServiceName,
+							CallCount: 1,
+						}
+					} else {
+						deps[depKey].CallCount++
+					}
+				} else if isClientSpan(s) && !hasCorrespondingServerSpan(s, trace.Spans) {
+
+					// Generate a unique ID based on current time and a counter
+					currentTime := uint64(time.Now().UnixNano())
+					uniqueID := (currentTime << 32) | (atomic.AddUint64(&counter, 1) & 0xFFFFFFFF)
+
+					// Creating an artificial server span
+					artificialSpan := &model.Span{
+						TraceID:       s.TraceID,                                         // Keeping the same trace ID
+						SpanID:        model.NewSpanID(uniqueID),                         // Generating a new span ID
+						OperationName: "artificial-" + s.OperationName,                   // TODO
+						StartTime:     s.StartTime,                                       // Starting time can be the same as the client span
+						Duration:      s.Duration,                                        // Duration can also be copied or set as needed
+						Flags:         s.Flags,                                           // Flags can be copied
+						Process:       &model.Process{ServiceName: "artificial-service"}, // TODO: Set service name as needed
+						Tags: model.KeyValues{
+							model.String("span.kind", "server"), // This is an artificial server span
+							model.String("artificial", "true"),  // Tag to identify it as artificial
+						},
+					}
+
+					// Adding the artificial span to the trace
+					trace.Spans = append(trace.Spans, artificialSpan)
+
+					// Handle dependencies if needed, for example, increment the call count between services
+					parentService := s.Process.ServiceName
+					childService := "artificial-" + s.OperationName // TODO: another method to name the uninstrumented service
+					depKey := parentService + "&&&" + childService
+					if _, ok := deps[depKey]; !ok {
+						deps[depKey] = &model.DependencyLink{
+							Parent:    parentService,
+							Child:     childService,
 							CallCount: 1,
 						}
 					} else {
@@ -338,4 +379,22 @@ func flattenTags(span *model.Span) model.KeyValues {
 		retMe = append(retMe, l.Fields...)
 	}
 	return retMe
+}
+
+func hasCorrespondingServerSpan(clientSpan *model.Span, spans []*model.Span) bool {
+	for _, span := range spans {
+		if span.ParentSpanID() == clientSpan.SpanID {
+			return true
+		}
+	}
+	return false
+}
+
+func isClientSpan(span *model.Span) bool {
+	for _, tag := range span.Tags {
+		if tag.Key == "span.kind" && tag.VStr == "client" {
+			return true
+		}
+	}
+	return false
 }

--- a/plugin/storage/memory/memory.go
+++ b/plugin/storage/memory/memory.go
@@ -368,45 +368,40 @@ func updateServiceDependencyLinks(parentService, childService string, deps map[s
 }
 
 func inferServiceName(span *model.Span) string {
-    serviceName := "inferred"
+	serviceName := "inferred"
 
-    // Check for peer.service tag
-    if peerService, found := getTagValue(span, "peer.service"); found {
-        return serviceName + "-" + peerService
-    }
+	// Check for peer.service tag
+	if peerService, found := getTagValue(span, "peer.service"); found {
+		return serviceName + "-" + peerService
+	}
 
-    // Check for RPC service name
-    if rpcService, found := getTagValue(span, "rpc.service"); found {
-        return serviceName + "-rpc-" + rpcService
-    }
+	// Check for RPC service name
+	if rpcService, found := getTagValue(span, "rpc.service"); found {
+		return serviceName + "-rpc-" + rpcService
+	}
 
-    // Check for HTTP service name via route or URL
-    if httpRoute, found := getTagValue(span, "http.route"); found {
-        return serviceName + "-http-" + httpRoute
-    } else if httpURL, found := getTagValue(span, "http.url"); found {
-        return serviceName + "-http-" + httpURL 
-    }
+	// Check for HTTP service name via route or URL
+	if httpRoute, found := getTagValue(span, "http.route"); found {
+		return serviceName + "-http-" + httpRoute
+	}
 
-    // Check for Database service name via DB name or connection string
-    if dbSystem, found := getTagValue(span, "db.system"); found {
-        dbName := dbSystem
-        if dbName == "" {
-            dbName = "unknown"
-        }
-        if dbStatement, found := getTagValue(span, "db.statement"); found {
-            dbName += "-" + dbStatement 
-        }
-        return serviceName + "-db-" + dbName
-    }
+	// Check for Database service name via DB name or connection string
+	if dbSystem, found := getTagValue(span, "db.system"); found {
+		dbName := dbSystem
+		if dbName == "" {
+			dbName = "unknown"
+		}
+		return serviceName + "-db-" + dbName
+	}
 
-    return serviceName + "-" + span.OperationName
+	return serviceName + "-" + span.OperationName
 }
 
 func getTagValue(span *model.Span, key string) (string, bool) {
-    for _, tag := range span.Tags {
-        if tag.Key == key {
-            return tag.VStr, true
-        }
-    }
-    return "", false
+	for _, tag := range span.Tags {
+		if tag.Key == key {
+			return tag.VStr, true
+		}
+	}
+	return "", false
 }

--- a/plugin/storage/memory/memory_test.go
+++ b/plugin/storage/memory/memory_test.go
@@ -17,7 +17,6 @@ package memory
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -526,96 +525,40 @@ func makeTestingSpan(traceID model.TraceID, suffix string) *model.Span {
 	}
 }
 
-// TestInferredServiceDependency tests if the service dependencies include an inferred service
-// when there is a client span without a corresponding server span.
-func TestInferredServiceDependency(t *testing.T) {
+func TestGetDependencies(t *testing.T) {
 	scenarios := []struct {
-		description             string
-		clientSpanTags          model.KeyValues
-		childSpanTags           model.KeyValues
-		expectedDependency      model.DependencyLink
-		clientSpanOperationName string
+		description  string
+		setupSpans   func() []*model.Span
+		endTs        time.Time
+		lookback     time.Duration
+		expectedDeps []model.DependencyLink
 	}{
 		{
-			description:    "span.kind=client which is NOT a leaf (has a child)",
-			clientSpanTags: model.KeyValues{model.String("span.kind", "client")},
-			childSpanTags:  model.KeyValues{model.String("span.kind", "server")},
-			expectedDependency: model.DependencyLink{
-				Parent: "clientService",
-				Child:  "inferred-clientOperation",
-			},
-			clientSpanOperationName: "clientOperation",
-		},
-		{
-			description:    "leaf span that is NOT span.kind=client",
-			clientSpanTags: model.KeyValues{model.String("span.kind", "server")},
-			childSpanTags:  model.KeyValues{},
-			expectedDependency: model.DependencyLink{
-				Parent: "clientService",
-				Child:  "inferred-leaf-clientOperation",
-			},
-			clientSpanOperationName: "clientOperation",
-		},
-		{
-			description:    "client span that is a leaf and has no corresponding server span",
-			clientSpanTags: model.KeyValues{model.String("span.kind", "client")},
-			childSpanTags:  model.KeyValues{},
-			expectedDependency: model.DependencyLink{
-				Parent: "clientService",
-				Child:  "inferred-clientOperation",
-			},
-			clientSpanOperationName: "clientOperation",
-		},
-		{
-			description:    "span.kind=client which is NOT a leaf but child is not server",
-			clientSpanTags: model.KeyValues{model.String("span.kind", "client")},
-			childSpanTags:  model.KeyValues{model.String("span.kind", "consumer")},
-			expectedDependency: model.DependencyLink{
-				Parent: "clientService",
-				Child:  "inferred-clientOperation",
-			},
-			clientSpanOperationName: "clientOperation",
-		},
-		{
-			description:    "non-client, non-server leaf span",
-			clientSpanTags: model.KeyValues{model.String("span.kind", "consumer")},
-			childSpanTags:  model.KeyValues{},
-			expectedDependency: model.DependencyLink{
-				Parent: "clientService",
-				Child:  "inferred-leaf-consumerOperation",
-			},
-			clientSpanOperationName: "consumerOperation",
-		},
-	}
-
-	for _, scenario := range scenarios {
-		t.Run(scenario.description, func(t *testing.T) {
-			store := NewStore()
-
-			// Client span
-			clientSpan := &model.Span{
-				TraceID:       model.NewTraceID(1, 2),
-				SpanID:        model.NewSpanID(3),
-				OperationName: scenario.clientSpanOperationName,
-				StartTime:     time.Now(),
-				Duration:      time.Millisecond * 500,
-				Tags:          scenario.clientSpanTags,
-				Process: &model.Process{
-					ServiceName: "clientService",
-				},
-			}
-
-			// Child span
-			var childSpan *model.Span
-			if len(scenario.childSpanTags) > 0 {
-				childSpan = &model.Span{
+			description: "Simple client-server relationship",
+			setupSpans: func() []*model.Span {
+				// Inline creation of client and server spans
+				now := time.Now()
+				clientSpan := &model.Span{
+					TraceID:       model.NewTraceID(1, 2),
+					SpanID:        model.NewSpanID(3),
+					OperationName: "clientOperation",
+					StartTime:     now,
+					Duration:      time.Millisecond * 500,
+					Tags:          model.KeyValues{model.String("span.kind", "client")},
+					Process: &model.Process{
+						ServiceName: "clientService",
+					},
+				}
+				serverSpan := &model.Span{
 					TraceID:       clientSpan.TraceID,
 					SpanID:        model.NewSpanID(4),
-					OperationName: "childOperation",
-					StartTime:     time.Now(),
-					Duration:      time.Millisecond * 300,
-					Tags:          scenario.childSpanTags,
-					Process:       clientSpan.Process,
+					OperationName: "serverOperation",
+					StartTime:     now.Add(time.Millisecond * 100),
+					Duration:      time.Millisecond * 500,
+					Tags:          model.KeyValues{model.String("span.kind", "server")},
+					Process: &model.Process{
+						ServiceName: "serverService",
+					},
 					References: []model.SpanRef{
 						{
 							RefType: model.ChildOf,
@@ -624,23 +567,116 @@ func TestInferredServiceDependency(t *testing.T) {
 						},
 					},
 				}
-			}
-
-			assert.NoError(t, store.WriteSpan(context.Background(), clientSpan))
-			if childSpan != nil {
-				assert.NoError(t, store.WriteSpan(context.Background(), childSpan))
-			}
-			dependencies, err := store.GetDependencies(context.Background(), time.Now(), time.Hour)
-			assert.NoError(t, err)
-
-			var hasExpectedDependency bool
-			for _, dependency := range dependencies {
-				if dependency.Parent == scenario.expectedDependency.Parent && dependency.Child == scenario.expectedDependency.Child {
-					hasExpectedDependency = true
-					break
+				return []*model.Span{clientSpan, serverSpan}
+			},
+			endTs:    time.Now().Add(1 * time.Second),
+			lookback: time.Hour,
+			expectedDeps: []model.DependencyLink{
+				{Parent: "clientService", Child: "serverService", CallCount: 1},
+			},
+		},
+		{
+			description: "Leaf client span with no server span",
+			setupSpans: func() []*model.Span {
+				now := time.Now()
+				clientSpan := &model.Span{
+					TraceID:       model.NewTraceID(1, 2),
+					SpanID:        model.NewSpanID(3),
+					OperationName: "clientOperation",
+					StartTime:     now.Add(-30 * time.Second), // 30 seconds ago
+					Duration:      time.Millisecond * 500,
+					Tags:          model.KeyValues{model.String("span.kind", "client")},
+					Process: &model.Process{
+						ServiceName: "clientService",
+					},
 				}
+				// No server span is created
+				return []*model.Span{clientSpan}
+			},
+			endTs:    time.Now().Add(1 * time.Second),
+			lookback: time.Hour,
+			expectedDeps: []model.DependencyLink{
+				// Depending on the logic of inferServiceName, the Child might be different
+				{Parent: "clientService", Child: "inferred::clientOperation", CallCount: 1},
+			},
+		},
+		{
+			description: "Leaf client span with no server span",
+			setupSpans: func() []*model.Span {
+				now := time.Now()
+				clientSpan := &model.Span{
+					TraceID:       model.NewTraceID(1, 2),
+					SpanID:        model.NewSpanID(3),
+					OperationName: "clientOperation",
+					StartTime:     now.Add(-30 * time.Second), // 30 seconds ago
+					Duration:      time.Millisecond * 500,
+					Tags:          model.KeyValues{model.String("span.kind", "client")},
+					Process: &model.Process{
+						ServiceName: "clientService",
+					},
+				}
+				// No server span is created
+				return []*model.Span{clientSpan}
+			},
+			endTs:        time.Now().Add(1 * time.Second),
+			lookback:     time.Hour,
+			expectedDeps: []model.DependencyLink{{Parent: "clientService", Child: "inferred::clientOperation", CallCount: 1}},
+		},
+		{
+			description: "span.kind=client which is NOT a leaf (has a child)",
+			setupSpans: func() []*model.Span {
+				now := time.Now()
+				clientSpan := &model.Span{
+					TraceID:       model.NewTraceID(1, 2),
+					SpanID:        model.NewSpanID(3),
+					OperationName: "clientOperation",
+					StartTime:     now,
+					Duration:      time.Millisecond * 500,
+					Tags:          model.KeyValues{model.String("span.kind", "client")},
+					Process: &model.Process{
+						ServiceName: "clientService",
+					},
+				}
+				serverSpan := &model.Span{
+					TraceID:       clientSpan.TraceID,
+					SpanID:        model.NewSpanID(4),
+					OperationName: "serverOperation",
+					StartTime:     now.Add(time.Millisecond * 100),
+					Duration:      time.Millisecond * 500,
+					Tags:          model.KeyValues{model.String("span.kind", "server")},
+					Process: &model.Process{
+						ServiceName: "serverService",
+					},
+					References: []model.SpanRef{
+						{
+							RefType: model.ChildOf,
+							TraceID: clientSpan.TraceID,
+							SpanID:  clientSpan.SpanID,
+						},
+					},
+				}
+				return []*model.Span{clientSpan, serverSpan}
+			},
+			endTs:    time.Now().Add(1 * time.Second),
+			lookback: time.Hour,
+			expectedDeps: []model.DependencyLink{
+				{Parent: "clientService", Child: "serverService", CallCount: 1},
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.description, func(t *testing.T) {
+			store := NewStore()
+			spans := scenario.setupSpans()
+
+			for _, span := range spans {
+				assert.NoError(t, store.WriteSpan(context.Background(), span))
 			}
-			assert.True(t, hasExpectedDependency, fmt.Sprintf("%s: expected service dependencies to include %v", scenario.description, scenario.expectedDependency))
+
+			dependencies, err := store.GetDependencies(context.Background(), scenario.endTs, scenario.lookback)
+			assert.NoError(t, err)
+			assert.Equal(t, scenario.expectedDeps, dependencies, "Dependencies do not match the expected output")
 		})
 	}
 }
@@ -709,34 +745,35 @@ func TestInferServiceName(t *testing.T) {
 			tags: model.KeyValues{
 				model.String("peer.service", "authService"),
 			},
-			expectedName: "inferred-authService",
+			expectedName: "authService",
 		},
 		{
 			tags: model.KeyValues{
 				model.String("rpc.service", "grpcService"),
 			},
-			expectedName: "inferred-rpc-grpcService",
+			expectedName: "rpc-grpcService",
 		},
 		{
 			tags: model.KeyValues{
 				model.String("http.route", "users"),
 			},
-			expectedName: "inferred-http-users",
+			expectedName: "http-users",
 		},
 		{
 			tags: model.KeyValues{
 				model.String("db.system", "mysql"),
 			},
-			expectedName: "inferred-db-mysql",
+			expectedName: "db-mysql",
+		},
+		{
+			tags: model.KeyValues{
+				model.String("db.system", ""),
+			},
+			expectedName: "db-unknown",
 		},
 		{
 			tags:         model.KeyValues{},
-			isLeaf:       true,
-			expectedName: "inferred-leaf-clientOperation",
-		},
-		{
-			tags:         model.KeyValues{},
-			expectedName: "inferred-clientOperation",
+			expectedName: "inferred::clientOperation",
 		},
 	}
 
@@ -746,7 +783,7 @@ func TestInferServiceName(t *testing.T) {
 			Tags:          scenario.tags,
 		}
 
-		inferredName := inferServiceName(span, scenario.isLeaf)
+		inferredName := inferServiceName(span)
 		assert.Equal(t, scenario.expectedName, inferredName, "Expected inferred service name to match")
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes 3804 

## Description of the changes
- Updated `GetDependencies` to identify and include client spans without corresponding server spans, ensuring a complete dependency graph.
- Implemented `updateServiceDependencyLinks` to streamline the update of service dependencies, reducing code duplication.
- Enabled the representation of uninstrumented services in the dependency graph by inferring names from client spans lacking server spans.

## How was this change tested?
- Introduced TestInferredServiceDependency to specifically evaluate the functionality of inferred service dependencies in the scenario of uninstrumented services.
- Created a client span without a corresponding server span and asserted the correct formation of dependencies, ensuring the inclusion of inferred services in the dependency graph.
- Employed assertions to confirm the presence and accuracy of inferred service dependencies, ensuring they are adequately represented with the correct attributes and relationships.


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
